### PR TITLE
 fix the bug that office program will shutdown once running the OfficeToPDF.exe command line tool

### DIFF
--- a/OfficeToPDF/Program.cs
+++ b/OfficeToPDF/Program.cs
@@ -90,7 +90,7 @@ namespace OfficeToPDF
             options["verbose"] = false;
             options["excludeprops"] = false;
             options["excludetags"] = false;
-            options["noquit"] = false;
+            options["noquit"] = true;
             options["merge"] = false;
             options["template"] = "";
             options["password"] = "";


### PR DESCRIPTION
This is for issue https://github.com/cognidox/OfficeToPDF/issues/53

While I am using outlook to view and deal with messages, and at same time I want to convert some messages into PDF, but whenever I run the command line .\OfficeToPDF.exe '.\outlookmessage.msg' 'convertedNewFile.pdf' it will shutdown the Word.exe and Outlook.exe, which is very inconvenient, why it would act like this, (from source code, seems it will release the session?
After debugging, I found that
in OutlookConverter.cs
try { app = (Microsoft.Office.Interop.Outlook.Application)Marshal.GetActiveObject("Outlook.Application"); } catch(System.Exception) { app = new Microsoft.Office.Interop.Outlook.Application(); running = false; } )

`  // If we were not already running, quit and release the outlook object
                if (app != null && !running)
                {
                    ((Microsoft.Office.Interop.Outlook._Application)app).Quit();
                }`
Why would we affect the current running app and session? Could we not shutdown the Outlook and Word app when running the converting job? 

I tried to fix it to make the initial variable ` options["noquit"] ` to true. I think it makes more sense.