### PR TITLE
Allow simple page range to be specified

### DIFF
--- a/OfficeToPDF/Converter.cs
+++ b/OfficeToPDF/Converter.cs
@@ -342,14 +342,14 @@ namespace OfficeToPDF
                     OpenMcdf.Extensions.OLEProperties.PropertySetStream ps = null;
                     try
                     {
-                        ps = summaryInfo.AsOLEProperties();
+                        ps = summaryInfo.AsOleProperties();
                     }
                     catch (Exception)
                     {
                         // There may be no properties for us to get
                         return false;
                     }
-                    int securityIdx = ps.PropertySet0.PropertyIdentifierAndOffsets.FindIndex(x => x.PropertyIdentifier == OpenMcdf.Extensions.OLEProperties.PropertyIdentifiersSummaryInfo.PIDSI_DOC_SECURITY);
+                    int securityIdx = ps.PropertySet0.PropertyIdentifierAndOffsets.FindIndex(x => x.PropertyIdentifier == OpenMcdf.Extensions.OLEProperties.PropertyIdentifiersSummaryInfo.PidsiDocSecurity);
                     if (securityIdx >= 0 && securityIdx < ps.PropertySet0.Properties.Count)
                     {
                         int security = (int)ps.PropertySet0.Properties[securityIdx].PropertyValue;

--- a/OfficeToPDF/OfficeToPDF.csproj
+++ b/OfficeToPDF/OfficeToPDF.csproj
@@ -111,52 +111,53 @@
     <Reference Include="Ghostscript.NET, Version=1.2.1.0, Culture=neutral, PublicKeyToken=f85051de34525b59, processorArchitecture=MSIL">
       <HintPath>..\packages\Ghostscript.NET.1.2.1\lib\net40\Ghostscript.NET.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Office.Interop.Excel, Version=12.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Interop.Microsoft.Office.Interop.OneNote, Version=1.1.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Interop.Microsoft.Office.Interop.OneNote.1.1.0.0\lib\net40\Interop.Microsoft.Office.Interop.OneNote.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
-      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft Visual Studio 9.0\Visual Studio Tools for Office\PIA\Office14\Microsoft.Office.Interop.Excel.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Office.Interop.MSProject, Version=12.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Microsoft.Office.Interop.Excel, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Office.Interop.Excel.15.0.4795.1000\lib\net20\Microsoft.Office.Interop.Excel.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
-      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft Visual Studio 9.0\Visual Studio Tools for Office\PIA\Office14\Microsoft.Office.Interop.MSProject.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Office.Interop.MSProject, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Ns.Microsoft.Office.Interop.All.15.0.0.2\lib\Microsoft.Office.Interop.MSProject.dll</HintPath>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.Office.Interop.OneNote, Version=12.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c">
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="Microsoft.Office.Interop.Outlook, Version=12.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Microsoft.Office.Interop.Outlook, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Office.Interop.Outlook.15.0.4797.1003\lib\net20\Microsoft.Office.Interop.Outlook.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="Microsoft.Office.Interop.PowerPoint, Version=12.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Microsoft.Office.Interop.PowerPoint, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Office.Interop.PowerPoint.15.0.4420.1017\lib\net20\Microsoft.Office.Interop.PowerPoint.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
     <Reference Include="Microsoft.Office.Interop.Publisher, Version=12.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c">
       <SpecificVersion>False</SpecificVersion>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="Microsoft.Office.Interop.Visio, Version=12.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Microsoft.Office.Interop.Visio, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Ns.Microsoft.Office.Interop.All.15.0.0.2\lib\Microsoft.Office.Interop.Visio.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="Microsoft.Office.Interop.Word, Version=12.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Microsoft.Office.Interop.Word, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.Office.Interop.Word.15.0.4797.1003\lib\net20\Microsoft.Office.Interop.Word.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
     </Reference>
-    <Reference Include="OFFICE, Version=12.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c">
-      <SpecificVersion>False</SpecificVersion>
+    <Reference Include="Office, Version=15.0.0.0, Culture=neutral, PublicKeyToken=71e9bce111e9429c, processorArchitecture=MSIL">
+      <HintPath>..\packages\Ns.Microsoft.Office.Interop.All.15.0.0.2\lib\Office.dll</HintPath>
       <EmbedInteropTypes>True</EmbedInteropTypes>
-      <HintPath>..\..\..\..\..\..\..\Program Files\Microsoft Visual Studio 9.0\Visual Studio Tools for Office\PIA\Office14\OFFICE.DLL</HintPath>
     </Reference>
-    <Reference Include="OpenMcdf, Version=2.1.1.5, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\OpenMcdf-2.2.1.1.5\lib\net40\OpenMcdf.dll</HintPath>
+    <Reference Include="OpenMcdf, Version=2.1.2.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\OpenMcdf-2.2.1.2\lib\net40\OpenMcdf.dll</HintPath>
     </Reference>
-    <Reference Include="PdfSharp-WPF, Version=1.31.5198.0, Culture=neutral, PublicKeyToken=f94615aa0424f9eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\kenjiuno.PdfSharp-WPF.1.31.5198\lib\net40\PdfSharp-WPF.dll</HintPath>
+    <Reference Include="PdfSharp-WPF, Version=1.31.5377.0, Culture=neutral, PublicKeyToken=f94615aa0424f9eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\kenjiuno.PdfSharp-WPF.1.31.5377\lib\net40\PdfSharp-WPF.dll</HintPath>
     </Reference>
-    <Reference Include="PdfSharp.Xps, Version=1.1.1.0, Culture=neutral, PublicKeyToken=f94615aa0424f9eb, processorArchitecture=MSIL">
-      <HintPath>..\packages\kenjiuno.PdfSharp.Xps.1.1.1\lib\net40\PdfSharp.Xps.dll</HintPath>
+    <Reference Include="PdfSharp.Xps, Version=1.1.4.0, Culture=neutral, PublicKeyToken=f94615aa0424f9eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\kenjiuno.PdfSharp.Xps.1.1.4\lib\net40\PdfSharp.Xps.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/OfficeToPDF/Program.cs
+++ b/OfficeToPDF/Program.cs
@@ -125,6 +125,8 @@ namespace OfficeToPDF
             options["word_markup_balloon"] = false;
             options["word_show_all_markup"] = false;
             options["word_fix_table_columns"] = false;
+            options["page_from"] = null;
+            options["page_to"] = null;
             options["original_filename"] = "";
             options["original_basename"] = "";
             options["powerpoint_output"] = "";
@@ -158,10 +160,12 @@ namespace OfficeToPDF
                 { "excel_max_rows", "Maximum number of rows" },
                 { "excel_worksheet", "Excel worksheet" },
                 { "word_max_pages", "Maximum number of pages" },
-                { "excel_delay", "Excel delay milliseconds" }
+                { "excel_delay", "Excel delay milliseconds" },
+                { "page_from", "Start of page range" },
+                { "page_to", "End of page range" }
             };
 
-            Regex switches = new Regex(@"^/(version|hidden|markup|readonly|bookmarks|merge|noquit|print|(fallback_)?printer|screen|pdfa|template|writepassword|password|help|verbose|exclude(props|tags)|excel_(delay|max_rows|show_formulas|show_headings|auto_macros|template_macros|active_sheet|worksheet|no_recalculate|no_link_update)|powerpoint_(output)|word_(header_dist|footer_dist|ref_fonts|no_field_update|field_quick_update(_safe)?|max_pages|keep_history|no_repair|fix_table_columns|show_(comments|revs_comments|format_changes|ink_annot|ins_del|all_markup)|markup_balloon)|pdf_(page_mode|append|prepend|layout|clean_meta|owner_pass|user_pass|restrict_(annotation|extraction|assembly|forms|modify|print|accessibility_extraction|full_quality))|working_dir|\?)$", RegexOptions.IgnoreCase);
+            Regex switches = new Regex(@"^/(page_from|page_to|version|hidden|markup|readonly|bookmarks|merge|noquit|print|(fallback_)?printer|screen|pdfa|template|writepassword|password|help|verbose|exclude(props|tags)|excel_(delay|max_rows|show_formulas|show_headings|auto_macros|template_macros|active_sheet|worksheet|no_recalculate|no_link_update)|powerpoint_(output)|word_(header_dist|footer_dist|ref_fonts|no_field_update|field_quick_update(_safe)?|max_pages|keep_history|no_repair|fix_table_columns|show_(comments|revs_comments|format_changes|ink_annot|ins_del|all_markup)|markup_balloon)|pdf_(page_mode|append|prepend|layout|clean_meta|owner_pass|user_pass|restrict_(annotation|extraction|assembly|forms|modify|print|accessibility_extraction|full_quality))|working_dir|\?)$", RegexOptions.IgnoreCase);
             for (int argIdx = 0; argIdx < args.Length; argIdx++)
             {
                 string item = args[argIdx];
@@ -371,6 +375,8 @@ namespace OfficeToPDF
                             case "excel_worksheet":
                             case "excel_delay":
                             case "word_max_pages":
+                            case "page_from":
+                            case "page_to":
                                 // Only accept the next option if there are enough options
                                 if (argIdx + 1 < args.Length)
                                 {
@@ -1101,6 +1107,8 @@ OfficeToPDF.exe [switches] input_file [output_file]
   /word_show_ins_del        - Show all markup when /markup is used.
   /word_show_all_markup     - Show all markup content when /markup is used.
   /word_markup_balloon      - Show balloon style markup messages rather than inline ones.
+  /page_from                - Start of page range
+  /page_to                  - End if page range
   /pdf_clean_meta <type>    - Allows for some meta-data to be removed from the generated PDF.
                               <type> can be:
                                 basic - removes author, keywords, creator and subject

--- a/OfficeToPDF/packages.config
+++ b/OfficeToPDF/packages.config
@@ -4,7 +4,13 @@
   <package id="DocumentFormat.OpenXml" version="2.9.1" targetFramework="net40" />
   <package id="Fody" version="4.2.1" targetFramework="net40" developmentDependency="true" />
   <package id="Ghostscript.NET" version="1.2.1" targetFramework="net40" />
-  <package id="kenjiuno.PdfSharp.Xps" version="1.1.1" targetFramework="net40" />
-  <package id="kenjiuno.PdfSharp-WPF" version="1.31.5198" targetFramework="net40" />
-  <package id="OpenMcdf-2" version="2.1.1.5" targetFramework="net40" />
+  <package id="Interop.Microsoft.Office.Interop.OneNote" version="1.1.0.0" targetFramework="net40" />
+  <package id="kenjiuno.PdfSharp.Xps" version="1.1.4" targetFramework="net40" />
+  <package id="kenjiuno.PdfSharp-WPF" version="1.31.5377" targetFramework="net40" />
+  <package id="Microsoft.Office.Interop.Excel" version="15.0.4795.1000" targetFramework="net40" />
+  <package id="Microsoft.Office.Interop.Outlook" version="15.0.4797.1003" targetFramework="net40" />
+  <package id="Microsoft.Office.Interop.PowerPoint" version="15.0.4420.1017" targetFramework="net40" />
+  <package id="Microsoft.Office.Interop.Word" version="15.0.4797.1003" targetFramework="net40" />
+  <package id="Ns.Microsoft.Office.Interop.All" version="15.0.0.2" targetFramework="net40" />
+  <package id="OpenMcdf-2" version="2.1.2" targetFramework="net40" />
 </packages>

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ The following optional switches can be used:
 | /word_show_ins_del         | show all markup when /markup is used |
 | /word_show_all_markup      | show all markup content when /markup is used |
 | /word_markup_balloon       | show balloon style markup messages rather than inline ones |
+| /page_from _num_           | Start of page range (Currently only supported for word documents) |
+| /page_to _num_             | End of page range (Currently only supported for word documents) |
 | /fallback_printer <name>   | print the document to postscript printer <name> for conversion when the main conversion routine fails. Requires Ghostscript to be installed |
 | /printer <name>            | print the document to postscript printer <name> for conversion. Requires Ghostscript to be installed |
 | /pdf_clean_meta _type_     | allows for some meta-data to be removed from the generated PDF<br>_type_ can be:<ul><li>basic - removes author, keywords, creator and subject</li><li>full - removes all that basic removes and also the title</li></ul> |


### PR DESCRIPTION
The following changes allow a page range to be specified when converting word documents to PDF. Perhaps it could later be generalised to other source types.

The changes are mixed up with some library updates, sorry if this is annoying.